### PR TITLE
Fix game link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GameJAM Player is a lightweight sandbox I use to iterate on jam-sized game ideas
 
 You can try a tiny HTML playground that mirrors the feel of my jam prototypes right from the browser:
 
-- [Play the GameJAM Player mini-demo](./gamejam-player.html)
+- [Play the GameJAM Player mini-demo](https://mairuis.github.io/gamejam-player.html)
 
 ## Connect
 


### PR DESCRIPTION
Update GameJAM Player link in README to point to the live GitHub Pages URL for direct playable demo access.

---
<a href="https://cursor.com/background-agent?bcId=bc-7acb3024-5ff3-42b5-b05d-59557ab23168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7acb3024-5ff3-42b5-b05d-59557ab23168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update README to change the GameJAM Player demo link from a relative path to the live GitHub Pages URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57cb5b40af0bebdbbcb75627f05b7c8cbfcafa9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->